### PR TITLE
更改Wired中文翻译

### DIFF
--- a/docs/issue-126.md
+++ b/docs/issue-126.md
@@ -140,7 +140,7 @@ RISC-V 目前有一些 CPU 的设计实现，比如阿里巴巴旗下半导体�
 
 ![](https://www.wangbase.com/blogimg/asset/202009/bg2020091709.jpg)
 
-> - [泰国国家公园](https://www.washingtonpost.com/travel/2020/09/18/tourist-trash-mail/)一旦发现乱丢垃圾的游客，就会把垃圾寄回它们。
+> - [泰国国家公园](https://www.washingtonpost.com/travel/2020/09/18/tourist-trash-mail/)一旦发现乱丢垃圾的游客，就会把垃圾寄回给他们。
 
 ![](https://www.wangbase.com/blogimg/asset/202009/bg2020092001.jpg)
 

--- a/docs/issue-134.md
+++ b/docs/issue-134.md
@@ -221,7 +221,7 @@ StackOverflow 的问答，算是一个小知识吧。手机热点的范围（10�
 
 ![](https://www.wangbase.com/blogimg/asset/202011/bg2020111801.jpg)
 
-华为 5G 的核心技术来自土耳其科学家 Erdal Arikan 的发现，本文是美国《有线》杂志对 Erdal Arikan 的访问记，介绍了背后的情况。文章比较长，但值得一读。
+华为 5G 的核心技术来自土耳其科学家 Erdal Arikan 的发现，本文是美国《连线》杂志对 Erdal Arikan 的访问记，介绍了背后的情况。文章比较长，但值得一读。
 
 7、[广电砸下百亿的CMMB手持电视](https://finance.sina.com.cn/tech/2020-10-12/doc-iivhuipp9118153.shtml)（中文）
 
@@ -405,7 +405,7 @@ X 是你所做的准备，Y 是你遇到的机会。
 -- [Hacker News 读者](https://news.ycombinator.com/item?id=24812391)
 
 5、
- 
+
 1820年，英格兰最著名的外科医生罗伯特·李斯特顿（Robert Liston）创造了一项世界记录，他做了历史上唯一一场死亡率达到300％的手术。
 
 他为一位肌肉坏死的病人截肢，沾过病人血液的手术刀不小心割伤了一位助手，旁边还有一位医师正在观摩手术。由于当时人们不知道细菌的存在，没有消毒意识，几天后，患者、助手、旁观医师相继死亡。


### PR DESCRIPTION
Wired杂志一般翻译为《连线》。
https://zh.wikipedia.org/zh-hans/%E8%BF%9E%E7%BA%BF