### PR TITLE
Fix broken urls.

### DIFF
--- a/docs/issue-29.md
+++ b/docs/issue-29.md
@@ -139,7 +139,7 @@ Flutter 开发的一个简单教程。
 
 本文介绍 GraphQL 的概念和优点，演示如何用 Express.js 搭建一个 GraphQL 后端。
 
-8、[HTML 网页的 head 元素 指南](https://gethead.info/)（英文）
+8、[HTML 网页的 head 元素 指南](https://htmlhead.dev/)（英文）
 
 网页的 `<head>` 元素可以放置很多东西，本文列出了其中一些主要的内容，可以当作参考手册。
 


### PR DESCRIPTION
该网站已经于 2019 年从 https://gethead.info/ 迁移到了 https://htmlhead.dev/ 。
参见：https://github.com/joshbuchea/HEAD/commit/7793fc3a658635f5ebc84dbaf1a88e6006e15f42

<!-- 
<details>

![image](https://user-images.githubusercontent.com/53334669/213169496-57fba3db-aabb-499d-8699-5c1b21a35ba2.png)
![image](https://user-images.githubusercontent.com/53334669/213169537-24fbd00a-12d4-4d3c-9dec-3fa09538543e.png)
</details>
-->