### PR TITLE
Update issue-270.md

### DIFF
--- a/docs/issue-270.md
+++ b/docs/issue-270.md
@@ -289,7 +289,7 @@ NASA 的宇航服就采用过这种颜色。
 
 ![](https://cdn.beekka.com/blogimg/asset/202304/bg2023040616.webp)
 
-金门大桥也采用这种颜色。
+四月二十五号大桥（位于葡萄牙里斯本）也采用这种颜色。
 
 ![](https://cdn.beekka.com/blogimg/asset/202304/bg2023040617.webp)
 


### PR DESCRIPTION
修正文中“金门大桥”为“四月二十五号大桥”——文中图片配置的为葡萄牙里斯本的“四月二十五号大桥”，文字编辑的为“金门大桥”。