### PR TITLE
fix: update Rslib site link

### DIFF
--- a/docs/issue-326.md
+++ b/docs/issue-326.md
@@ -85,7 +85,7 @@ Rspack 团队为了保证兼容性，向 Webpack 官方仓库做了100多次提�
 ![](https://cdn.beekka.com/blogimg/asset/202411/bg2024111004.webp)
 
 > - [Rsbuild](https://rsbuild.dev/zh/): 专注于构建 Web 应用。
-> - [Rslib](https://rspress.dev/zh/): 专注于构建 JS 软件包。
+> - [Rslib](https://lib.rsbuild.dev/zh/): 专注于构建 JS 软件包。
 > - [Rspress](https://rspress.dev/zh/)：专注于生成静态站点，比如文档和博客。
 > - [Rsdoctor](https://rsdoctor.dev/zh/)：专注于构建分析。
 


### PR DESCRIPTION
修复原博客文章中 Rslib 链接错误，将链接从 https://rspress.dev/zh/ 更正为 https://lib.rsbuild.dev/zh/。

目前，Rslib 站点尚未支持中文，但添加 `/zh/` 路径不会影响站点正常访问，并为未来支持中文提供兼容性。